### PR TITLE
增加 bindAddress 选项

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,12 @@ function MiAqaraPlatform(log, config, api) {
     this.log.info("**************************************************************");
     this.log.info("start success...");
     this.log.info("config gateways: " + this.log.objKey2Str(config['gateways']));
+
+    if (null == this.ConfigUtil.getBindAddress()) {
+        this.log.info("binding to the default interface");
+    } else {
+        this.log.info("bind address is: " + this.ConfigUtil.getBindAddress());
+    }
 }
 
 MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
@@ -84,11 +90,19 @@ MiAqaraPlatform.prototype.initServerSocket = function() {
     
     serverSocket.on('listening', function(){
         that.log.info("server is listening on port 9898.");
-        serverSocket.addMembership(multicastAddress);
+
+        if (null == that.ConfigUtil.getBindAddress()) {
+            serverSocket.addMembership(multicastAddress);
+        } else {
+            serverSocket.setMulticastInterface(that.ConfigUtil.getBindAddress());
+            serverSocket.addMembership(multicastAddress, that.ConfigUtil.getBindAddress());
+        }
     });
     
     serverSocket.on('message', this.parseMessage.bind(this));
-    
+
+    // We always bind to all interfaces here because we need to receive
+    // multicast traffic.
     serverSocket.bind(serverPort);
 }
 
@@ -171,11 +185,19 @@ MiAqaraPlatform.prototype.initServerSocket = function() {
     
     serverSocket.on('listening', function(){
         that.log.info("server is listening on port 9898.");
-        serverSocket.addMembership(multicastAddress);
+
+        if (null == that.ConfigUtil.getBindAddress()) {
+            serverSocket.addMembership(multicastAddress);
+        } else {
+            serverSocket.setMulticastInterface(that.ConfigUtil.getBindAddress());
+            serverSocket.addMembership(multicastAddress, that.ConfigUtil.getBindAddress());
+        }
     });
-    
+
     serverSocket.on('message', this.parseMessage.bind(this));
-    
+
+    // We always bind to all interfaces here because we need to receive
+    // multicast traffic.
     serverSocket.bind(serverPort);
 }
 

--- a/lib/ConfigUtil.js
+++ b/lib/ConfigUtil.js
@@ -10,7 +10,11 @@ class ConfigUtil {
             return false;
         }
     }
-    
+
+    getBindAddress() {
+        return this.config['bindAddress'];
+    }
+
     getGatewayPasswordByGatewaySid(gatewaySid) {
         return this.config['gateways'][gatewaySid];
     }


### PR DESCRIPTION
目前 homebridge-mi-aqara 在注册多播组的时候，如果安装的机器上有多个网卡，会随机选择一个网卡添加多播组（见：[https://nodejs.org/api/dgram.html#dgram_socket_addmembership_multicastaddress_multicastinterface](https://nodejs.org/api/dgram.html#dgram_socket_addmembership_multicastaddress_multicastinterface)）。

我家的 homebridge 是放在路由器上的，所以有的时候多播组会被添加到 WAN 侧的网卡。这种情况下 homebridge-mi-aqara 就会收不到智能网关的多播消息。所以这个 PR 添加了一个 bindAddress 选项，让用户可以手动指定应该添加多播组的网卡。比如以下的配置会让 homebridge-mi-aqara 将多播组添加到本地网络 LAN 侧（10.0.0.1/24）的网卡上：

```
"platforms": [
  {
    "platform": "MiAqaraPlatform",
    "bindAddress": "10.0.0.1",
    "gateways": {
      ...
    },
  }
]
```

希望能够将这个 PR merge 到下一个 release。谢谢！

[1] 另：`index.js` 中的 `initServerSocket` 好像被重复定义了两次？