### PR TITLE
Fakegato support for Temperature/Humidity Sensors, Motion Sensors and Contact Sensors

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,11 +91,11 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = oldSerial;
         } else if(accessory.displayName.match('MotionSensor')){
-          accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+          accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         } else if(accessory.displayName.match('ContactSensor')){
-          accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+          accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         }
@@ -563,10 +563,10 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('MotionSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('ContactSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function MiAqaraPlatform(log, config, api) {
     this.Service = Service;
     this.Characteristic = Characteristic;
     this.UUIDGen = UUIDGen;
+    this.HBpath = api.user.storagePath()+'/accessories';
     
     this.api = api;
     this.log = new LogUtil(null, log);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const dgram = require('dgram');
 const crypto = require('crypto');
+//const moment = require('moment');
 
 const packageFile = require("./package.json");
 const LogUtil = require('./lib/LogUtil');
@@ -17,11 +18,11 @@ const serverSocket = dgram.createSocket({
 const multicastAddress = '224.0.0.50';
 const multicastPort = 4321;
 const serverPort = 9898;
-const gatewayModels = ['gateway', 'gateway.v3', 'acpartner.v3'];
 
-var PlatformAccessory, Accessory, Service, Characteristic, UUIDGen;
+var PlatformAccessory, Accessory, Service, Characteristic, UUIDGen, FakeGatoHistoryService;
 
 module.exports = function(homebridge) {
+    FakeGatoHistoryService = require('fakegato-history')(homebridge)
     PlatformAccessory = homebridge.platformAccessory;
     Accessory = homebridge.hap.Accessory;
     Service = homebridge.hap.Service;
@@ -46,6 +47,7 @@ function MiAqaraPlatform(log, config, api) {
     this.api = api;
     this.log = new LogUtil(null, log);
     this.ConfigUtil = new ConfigUtil(config);
+    this.HBpath = api.user.storagePath()+'/accessories';
     
     this.GatewayUtil = new GatewayUtil();
     this.DeviceUtil = new DeviceUtil();
@@ -76,6 +78,10 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
     
     // accessory.reachable = true;
     if(that.AccessoryUtil) {
+        if(accessory.displayName.match('Temperature')){
+          accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+          accessory.context.loggingService.log = that.log.log;
+        }
         that.AccessoryUtil.add(accessory);
     }
 }
@@ -179,7 +185,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     try {
         jsonObj = JSON.parse(msg);
     } catch (ex) {
-        that.log.error("Bad msg: " + msg);
+        that.log.error("Bad msg %s", msg);
         return;
     }
     
@@ -187,33 +193,51 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     if (cmd === 'iam') {
         that.log.debug("[Revc]" + msg);
         var gatewaySid = jsonObj['sid'];
-        if(!that.ConfigUtil.isConfigGateway(gatewaySid)) return;
-
-        that.GatewayUtil.addOrUpdate(gatewaySid, {
-            sid: gatewaySid,
-            passwd: that.ConfigUtil.getGatewayPasswordByGatewaySid(gatewaySid),
-            ip: jsonObj['ip'],
-            port: jsonObj['port'],
-            protoVersion: jsonObj['proto_version']
-        });
-
-        if(jsonObj['proto_version']) {
-            //if whois return proto_version, select query commands based on version
-            this.getSubDevice(gatewaySid);
-        } else {
-            //get version by read command
-            that.addDevice(gatewaySid, gatewaySid);
-            this.getProtoVersionAndSubDevice(gatewaySid);
+        if(that.ConfigUtil.isConfigGateway(gatewaySid)) {
+            var ip = jsonObj['ip'];
+            var port = jsonObj['port'];
+            var listCmd = '{"cmd":"get_id_list"}';
+            that.log.debug("[Send]" + listCmd);
+            serverSocket.send(listCmd, 0, listCmd.length, port, ip);
         }
-    } else if (cmd === 'get_id_list_ack' || cmd === 'discovery_rsp') {
+    } else if (cmd === 'get_id_list_ack') {
         that.log.debug("[Revc]" + msg);
         var gatewaySid = jsonObj['sid'];
-        that.GatewayUtil.addOrUpdate(gatewaySid, {
-            sid: gatewaySid,
-            token: jsonObj['token']
-        });
-
-        var data = that.isProtoVersionByGid(gatewaySid, 2) ? jsonObj['dev_list'] : JSON.parse(jsonObj['data']);
+        var gateway = that.GatewayUtil.getBySid(gatewaySid);
+        if(!gateway) {
+            gateway = {
+                sid: gatewaySid,
+                passwd: that.ConfigUtil.getGatewayPasswordByGatewaySid(gatewaySid),
+                ip: rinfo.address,
+                port: rinfo.port,
+                token: jsonObj['token']
+            }
+            that.GatewayUtil.addOrUpdate(gatewaySid, gateway);
+        }
+        
+        if(!that.DeviceUtil.getBySid(gatewaySid)) {
+            var gatewayDevice = {
+                sid: gatewaySid,
+                gatewaySid: gatewaySid,
+                lastUpdateTime: Date.now()
+            }
+            that.DeviceUtil.addOrUpdate(gatewaySid, gatewayDevice);
+            
+            var command1 = '{"cmd":"read", "sid":"' + gatewaySid + '"}';
+            that.sendReadCommand(gatewaySid, command1, {timeout: 0.5 * 60 * 1000, retryCount: 12}).then(result => {
+                that.DeviceUtil.update({model: result['model']});
+                var createAccessories = that.ParseUtil.getCreateAccessories(result);
+                that.registerPlatformAccessories(createAccessories);
+                that.ParseUtil.parserAccessories(result);
+                
+                that.deleteDisableAccessories(result['sid'], result['model']);
+            }).catch(function(err) {
+                that.DeviceUtil.remove(gatewaySid);
+                that.log.error(err);
+            });
+        }
+        
+        var data = JSON.parse(jsonObj['data']);
         var index = 0;
         var sendInterval = setInterval(() => {
             if(index >= data.length) {
@@ -222,7 +246,28 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
                 return;
             }
             
-            that.addDevice(that.isProtoVersionByGid(gatewaySid, 2) ? data[index]['sid'] : data[index], gatewaySid);
+            var deviceSid = data[index];
+            if(!that.DeviceUtil.getBySid(deviceSid)) {
+                var device = {
+                    sid: deviceSid,
+                    gatewaySid: gatewaySid,
+                    lastUpdateTime: Date.now()
+                }
+                that.DeviceUtil.addOrUpdate(deviceSid, device);
+                
+                var command2 = '{"cmd":"read", "sid":"' + deviceSid + '"}';
+                that.sendReadCommand(deviceSid, command2, {timeout: 3 * 1000, retryCount: 12}).then(result => {
+                    that.DeviceUtil.update({model: result['model']});
+                    var createAccessories = that.ParseUtil.getCreateAccessories(result);
+                    that.registerPlatformAccessories(createAccessories);
+                    that.ParseUtil.parserAccessories(result);
+                    
+                    that.deleteDisableAccessories(result['sid'], result['model']);
+                }).catch(function(err) {
+                    that.DeviceUtil.remove(deviceSid);
+                    that.log.error(err);
+                });
+            }
             
             index++;
         }, 50);
@@ -231,7 +276,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
         var model = jsonObj['model'];
         var sid = jsonObj['sid'];
         
-        if (gatewayModels.indexOf(model) != -1) {
+        if (model === 'gateway') {
             that.GatewayUtil.update(sid, {token: jsonObj['token']});
         }
 
@@ -242,7 +287,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
             that.DeviceUtil.update(sid, {lastUpdateTime: newLastUpdateTime});
         } else {
         }
-    } else if (cmd === 'write_ack' || cmd === 'write_rsp') {
+    } else if (cmd === 'write_ack') {
         var msgTag = 'write_' + jsonObj['sid'];
         const p = that.getPromises(msgTag);
         if(!p) {
@@ -258,7 +303,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
                 p.resolve(jsonObj);
             }
         }
-    } else if (cmd === 'read_ack' || cmd === 'read_rsp') {
+    } else if (cmd === 'read_ack') {
         var msgTag = 'read_' + jsonObj['sid'];
         const p = that.getPromises(msgTag);
         if(!p) {
@@ -280,76 +325,6 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     } else {
         that.log.warn("[Revc]" + msg);
     }
-}
-
-MiAqaraPlatform.prototype.isProtoVersionByGid = function(sid, num) {
-    var gateway = sid && this.GatewayUtil.getBySid(sid);
-    return (gateway && gateway.protoVersion || '1.x').substring(0, 2) === (num + '.');
-}
-MiAqaraPlatform.prototype.isProtoVersionByDid = function(did, num) {
-    var device = this.DeviceUtil.getBySid(did);
-    return this.isProtoVersionByGid(device && device.gatewaySid, num);
-}
-
-MiAqaraPlatform.prototype.getSubDevice = function(gatewaySid) {
-    var that = this;
-    var gateway = that.GatewayUtil.getBySid(gatewaySid);
-    if (that.isProtoVersionByGid(gatewaySid, 2)) {
-        var listCmd = '{"cmd":"discovery"}';
-        that.log.debug("[Send]" + listCmd);
-        serverSocket.send(listCmd, 0, listCmd.length, gateway.port, gateway.ip);
-    } else {
-        //default version 1
-        var listCmd = '{"cmd":"get_id_list"}';
-        that.log.debug("[Send]" + listCmd);
-        serverSocket.send(listCmd, 0, listCmd.length, gateway.port, gateway.ip);
-    }
-    return;
-}
-
-MiAqaraPlatform.prototype.getProtoVersionAndSubDevice = function(gatewaySid) {
-    var that = this;
-    var command = '{"cmd":"read", "sid":"' + gatewaySid + '"}';
-    this.sendReadCommand(gatewaySid, command, {timeout: 3 * 1000, retryCount: 12}).then(result => {
-        var protoVersion = result['data'] && result['data']['proto_version'];
-        if (!protoVersion && result['params']) {
-            result['params'].forEach((param) => {
-                if (param['proto_version']) {
-                    protoVersion = param['proto_version'];
-                }
-            });
-        }
-        that.GatewayUtil.addOrUpdate(gatewaySid, {
-            sid: gatewaySid,
-            protoVersion: protoVersion
-        });
-        that.getSubDevice(gatewaySid);
-    }).catch(function(err) {
-        that.log.error(err);
-    });
-}
-
-MiAqaraPlatform.prototype.addDevice = function(deviceSid, gatewaySid) {
-    if(this.DeviceUtil.getBySid(deviceSid)) return;
-    var device = {
-        sid: deviceSid,
-        gatewaySid: gatewaySid,
-        lastUpdateTime: Date.now()
-    }
-    this.DeviceUtil.addOrUpdate(deviceSid, device);
-    var that = this;
-    var command = '{"cmd":"read", "sid":"' + deviceSid + '"}';
-    this.sendReadCommand(deviceSid, command, {timeout: 3 * 1000, retryCount: 12}).then(result => {
-        that.DeviceUtil.update({model: result['model']});
-        var createAccessories = that.ParseUtil.getCreateAccessories(result);
-        that.registerPlatformAccessories(createAccessories);
-        that.ParseUtil.parserAccessories(result);
-
-        that.deleteDisableAccessories(result['sid'], result['model']);
-    }).catch(function(err) {
-        that.DeviceUtil.remove(deviceSid);
-        that.log.error(err);
-    });
 }
 
 MiAqaraPlatform.prototype.getPromises = function(msgTag) {
@@ -462,10 +437,6 @@ MiAqaraPlatform.prototype.sendReadCommand = function(deviceSid, command, options
     var that = this;
     return new Promise((resolve, reject) => {
         var device = that.DeviceUtil.getBySid(deviceSid);
-        if (!device) {
-            reject('no such device: ' + deviceSid);
-            return;
-        }
         var gateway = that.GatewayUtil.getBySid(device.gatewaySid);
         var msgTag = 'read_' + deviceSid + "_t" + that.getPromisesTagSerialNumber();
         that.sendCommand(gateway.ip, gateway.port, msgTag, command, options).then(result => {
@@ -481,26 +452,16 @@ MiAqaraPlatform.prototype.sendWriteCommand = function(deviceSid, command, option
     var that = this;
     return new Promise((resolve, reject) => {
         var device = that.DeviceUtil.getBySid(deviceSid);
-        if (!device) {
-            reject('no such device: ' + deviceSid);
-            return;
-        }
         var gateway = that.GatewayUtil.getBySid(device.gatewaySid);
         
         var cipher = crypto.createCipheriv('aes-128-cbc', that.ConfigUtil.getGatewayPasswordByGatewaySid(gateway['sid']), iv);
         var gatewayToken = gateway['token'];
         var key = cipher.update(gatewayToken, "ascii", "hex");
         cipher.final('hex'); // Useless data, don't know why yet.
-
-        if (that.isProtoVersionByGid(device.gatewaySid, 2)) {
-            command.key = key;
-            command.params = [command.data];
-            delete command.data;
-        } else {
-            command.data.key = key;
-        }
+        
+        command = command.replace('${key}', key);
         var msgTag = 'write_' + deviceSid + "_t" + that.getPromisesTagSerialNumber();
-        that.sendCommand(gateway.ip, gateway.port, msgTag, JSON.stringify(command), options).then(result => {
+        that.sendCommand(gateway.ip, gateway.port, msgTag, command, options).then(result => {
             resolve(result);
         }).catch(function(err) {
             // that.log.error(err);
@@ -518,17 +479,10 @@ MiAqaraPlatform.prototype.sendWriteCommandWithoutFeedback = function(deviceSid, 
     var gatewayToken = gateway['token'];
     var key = cipher.update(gatewayToken, "ascii", "hex");
     cipher.final('hex'); // Useless data, don't know why yet.
-
-    if (that.isProtoVersionByGid(device.gatewaySid, 2)) {
-        command.key = key;
-        command.params = [command.data];
-        delete command.data;
-    } else {
-        command.data.key = key;
-    }
-    var commandStr = JSON.stringify(command);
-    that.log.debug("[Send]" + commandStr);
-    serverSocket.send(commandStr, 0, commandStr.length, gateway.port, gateway.ip, err => err && reject(err));
+    
+    command = command.replace('${key}', key);
+    that.log.debug("[Send]" + command);
+    serverSocket.send(command, 0, command.length, gateway.port, gateway.ip, err => err && reject(err));
 }
 
 MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {

--- a/index.js
+++ b/index.js
@@ -78,8 +78,11 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
     
     // accessory.reachable = true;
     if(that.AccessoryUtil) {
-        if(accessory.displayName.match('Temperature')){
+        if(accessory.displayName.match('TemperatureAndHumiditySensor')){
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService.log = that.log.log;
+        } else if(accessory.displayName.match('MotionSensor')){
+            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);
@@ -542,8 +545,11 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
     that.api.registerPlatformAccessories("homebridge-mi-aqara", "MiAqaraPlatform", accessories);
     accessories.forEach(function(accessory, index, arr) {
         that.log.info("create accessory - UUID: " + accessory.UUID);
-        if(accessory.displayName.match('Temperature')){
+        if(accessory.displayName.match('TemperatureAndHumiditySensor')){
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService.log = that.log.log;
+        } else if(accessory.displayName.match('MotionSensor')){
+            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);

--- a/index.js
+++ b/index.js
@@ -91,11 +91,11 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = oldSerial;
         } else if(accessory.displayName.match('MotionSensor')){
-          accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+          accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         } else if(accessory.displayName.match('ContactSensor')){
-          accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+          accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
           accessory.context.loggingService.log = that.log.log;
           accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         }
@@ -563,10 +563,10 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('MotionSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('ContactSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);

--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
     // accessory.reachable = true;
     if(that.AccessoryUtil) {
         if(accessory.displayName.match('Temperature')){
-          accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
-          accessory.context.loggingService.log = that.log.log;
+            accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);
     }
@@ -542,6 +542,10 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
     that.api.registerPlatformAccessories("homebridge-mi-aqara", "MiAqaraPlatform", accessories);
     accessories.forEach(function(accessory, index, arr) {
         that.log.info("create accessory - UUID: " + accessory.UUID);
+        if(accessory.displayName.match('Temperature')){
+            accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+            accessory.context.loggingService.log = that.log.log;
+        }
         that.AccessoryUtil.add(accessory);
     });
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const dgram = require('dgram');
 const crypto = require('crypto');
-//const moment = require('moment');
 
 const packageFile = require("./package.json");
 const LogUtil = require('./lib/LogUtil');
@@ -18,6 +17,7 @@ const serverSocket = dgram.createSocket({
 const multicastAddress = '224.0.0.50';
 const multicastPort = 4321;
 const serverPort = 9898;
+const gatewayModels = ['gateway', 'gateway.v3', 'acpartner.v3'];
 
 var PlatformAccessory, Accessory, Service, Characteristic, UUIDGen, FakeGatoHistoryService;
 
@@ -47,7 +47,6 @@ function MiAqaraPlatform(log, config, api) {
     this.api = api;
     this.log = new LogUtil(null, log);
     this.ConfigUtil = new ConfigUtil(config);
-    this.HBpath = api.user.storagePath()+'/accessories';
     
     this.GatewayUtil = new GatewayUtil();
     this.DeviceUtil = new DeviceUtil();
@@ -185,7 +184,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     try {
         jsonObj = JSON.parse(msg);
     } catch (ex) {
-        that.log.error("Bad msg %s", msg);
+        that.log.error("Bad msg: " + msg);
         return;
     }
     
@@ -193,51 +192,33 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     if (cmd === 'iam') {
         that.log.debug("[Revc]" + msg);
         var gatewaySid = jsonObj['sid'];
-        if(that.ConfigUtil.isConfigGateway(gatewaySid)) {
-            var ip = jsonObj['ip'];
-            var port = jsonObj['port'];
-            var listCmd = '{"cmd":"get_id_list"}';
-            that.log.debug("[Send]" + listCmd);
-            serverSocket.send(listCmd, 0, listCmd.length, port, ip);
+        if(!that.ConfigUtil.isConfigGateway(gatewaySid)) return;
+
+        that.GatewayUtil.addOrUpdate(gatewaySid, {
+            sid: gatewaySid,
+            passwd: that.ConfigUtil.getGatewayPasswordByGatewaySid(gatewaySid),
+            ip: jsonObj['ip'],
+            port: jsonObj['port'],
+            protoVersion: jsonObj['proto_version']
+        });
+
+        if(jsonObj['proto_version']) {
+            //if whois return proto_version, select query commands based on version
+            this.getSubDevice(gatewaySid);
+        } else {
+            //get version by read command
+            that.addDevice(gatewaySid, gatewaySid);
+            this.getProtoVersionAndSubDevice(gatewaySid);
         }
-    } else if (cmd === 'get_id_list_ack') {
+    } else if (cmd === 'get_id_list_ack' || cmd === 'discovery_rsp') {
         that.log.debug("[Revc]" + msg);
         var gatewaySid = jsonObj['sid'];
-        var gateway = that.GatewayUtil.getBySid(gatewaySid);
-        if(!gateway) {
-            gateway = {
-                sid: gatewaySid,
-                passwd: that.ConfigUtil.getGatewayPasswordByGatewaySid(gatewaySid),
-                ip: rinfo.address,
-                port: rinfo.port,
-                token: jsonObj['token']
-            }
-            that.GatewayUtil.addOrUpdate(gatewaySid, gateway);
-        }
-        
-        if(!that.DeviceUtil.getBySid(gatewaySid)) {
-            var gatewayDevice = {
-                sid: gatewaySid,
-                gatewaySid: gatewaySid,
-                lastUpdateTime: Date.now()
-            }
-            that.DeviceUtil.addOrUpdate(gatewaySid, gatewayDevice);
-            
-            var command1 = '{"cmd":"read", "sid":"' + gatewaySid + '"}';
-            that.sendReadCommand(gatewaySid, command1, {timeout: 0.5 * 60 * 1000, retryCount: 12}).then(result => {
-                that.DeviceUtil.update({model: result['model']});
-                var createAccessories = that.ParseUtil.getCreateAccessories(result);
-                that.registerPlatformAccessories(createAccessories);
-                that.ParseUtil.parserAccessories(result);
-                
-                that.deleteDisableAccessories(result['sid'], result['model']);
-            }).catch(function(err) {
-                that.DeviceUtil.remove(gatewaySid);
-                that.log.error(err);
-            });
-        }
-        
-        var data = JSON.parse(jsonObj['data']);
+        that.GatewayUtil.addOrUpdate(gatewaySid, {
+            sid: gatewaySid,
+            token: jsonObj['token']
+        });
+
+        var data = that.isProtoVersionByGid(gatewaySid, 2) ? jsonObj['dev_list'] : JSON.parse(jsonObj['data']);
         var index = 0;
         var sendInterval = setInterval(() => {
             if(index >= data.length) {
@@ -246,28 +227,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
                 return;
             }
             
-            var deviceSid = data[index];
-            if(!that.DeviceUtil.getBySid(deviceSid)) {
-                var device = {
-                    sid: deviceSid,
-                    gatewaySid: gatewaySid,
-                    lastUpdateTime: Date.now()
-                }
-                that.DeviceUtil.addOrUpdate(deviceSid, device);
-                
-                var command2 = '{"cmd":"read", "sid":"' + deviceSid + '"}';
-                that.sendReadCommand(deviceSid, command2, {timeout: 3 * 1000, retryCount: 12}).then(result => {
-                    that.DeviceUtil.update({model: result['model']});
-                    var createAccessories = that.ParseUtil.getCreateAccessories(result);
-                    that.registerPlatformAccessories(createAccessories);
-                    that.ParseUtil.parserAccessories(result);
-                    
-                    that.deleteDisableAccessories(result['sid'], result['model']);
-                }).catch(function(err) {
-                    that.DeviceUtil.remove(deviceSid);
-                    that.log.error(err);
-                });
-            }
+            that.addDevice(that.isProtoVersionByGid(gatewaySid, 2) ? data[index]['sid'] : data[index], gatewaySid);
             
             index++;
         }, 50);
@@ -276,7 +236,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
         var model = jsonObj['model'];
         var sid = jsonObj['sid'];
         
-        if (model === 'gateway') {
+        if (gatewayModels.indexOf(model) != -1) {
             that.GatewayUtil.update(sid, {token: jsonObj['token']});
         }
 
@@ -287,7 +247,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
             that.DeviceUtil.update(sid, {lastUpdateTime: newLastUpdateTime});
         } else {
         }
-    } else if (cmd === 'write_ack') {
+    } else if (cmd === 'write_ack' || cmd === 'write_rsp') {
         var msgTag = 'write_' + jsonObj['sid'];
         const p = that.getPromises(msgTag);
         if(!p) {
@@ -303,7 +263,7 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
                 p.resolve(jsonObj);
             }
         }
-    } else if (cmd === 'read_ack') {
+    } else if (cmd === 'read_ack' || cmd === 'read_rsp') {
         var msgTag = 'read_' + jsonObj['sid'];
         const p = that.getPromises(msgTag);
         if(!p) {
@@ -325,6 +285,76 @@ MiAqaraPlatform.prototype.parseMessage = function(msg, rinfo){
     } else {
         that.log.warn("[Revc]" + msg);
     }
+}
+
+MiAqaraPlatform.prototype.isProtoVersionByGid = function(sid, num) {
+    var gateway = sid && this.GatewayUtil.getBySid(sid);
+    return (gateway && gateway.protoVersion || '1.x').substring(0, 2) === (num + '.');
+}
+MiAqaraPlatform.prototype.isProtoVersionByDid = function(did, num) {
+    var device = this.DeviceUtil.getBySid(did);
+    return this.isProtoVersionByGid(device && device.gatewaySid, num);
+}
+
+MiAqaraPlatform.prototype.getSubDevice = function(gatewaySid) {
+    var that = this;
+    var gateway = that.GatewayUtil.getBySid(gatewaySid);
+    if (that.isProtoVersionByGid(gatewaySid, 2)) {
+        var listCmd = '{"cmd":"discovery"}';
+        that.log.debug("[Send]" + listCmd);
+        serverSocket.send(listCmd, 0, listCmd.length, gateway.port, gateway.ip);
+    } else {
+        //default version 1
+        var listCmd = '{"cmd":"get_id_list"}';
+        that.log.debug("[Send]" + listCmd);
+        serverSocket.send(listCmd, 0, listCmd.length, gateway.port, gateway.ip);
+    }
+    return;
+}
+
+MiAqaraPlatform.prototype.getProtoVersionAndSubDevice = function(gatewaySid) {
+    var that = this;
+    var command = '{"cmd":"read", "sid":"' + gatewaySid + '"}';
+    this.sendReadCommand(gatewaySid, command, {timeout: 3 * 1000, retryCount: 12}).then(result => {
+        var protoVersion = result['data'] && result['data']['proto_version'];
+        if (!protoVersion && result['params']) {
+            result['params'].forEach((param) => {
+                if (param['proto_version']) {
+                    protoVersion = param['proto_version'];
+                }
+            });
+        }
+        that.GatewayUtil.addOrUpdate(gatewaySid, {
+            sid: gatewaySid,
+            protoVersion: protoVersion
+        });
+        that.getSubDevice(gatewaySid);
+    }).catch(function(err) {
+        that.log.error(err);
+    });
+}
+
+MiAqaraPlatform.prototype.addDevice = function(deviceSid, gatewaySid) {
+    if(this.DeviceUtil.getBySid(deviceSid)) return;
+    var device = {
+        sid: deviceSid,
+        gatewaySid: gatewaySid,
+        lastUpdateTime: Date.now()
+    }
+    this.DeviceUtil.addOrUpdate(deviceSid, device);
+    var that = this;
+    var command = '{"cmd":"read", "sid":"' + deviceSid + '"}';
+    this.sendReadCommand(deviceSid, command, {timeout: 3 * 1000, retryCount: 12}).then(result => {
+        that.DeviceUtil.update({model: result['model']});
+        var createAccessories = that.ParseUtil.getCreateAccessories(result);
+        that.registerPlatformAccessories(createAccessories);
+        that.ParseUtil.parserAccessories(result);
+
+        that.deleteDisableAccessories(result['sid'], result['model']);
+    }).catch(function(err) {
+        that.DeviceUtil.remove(deviceSid);
+        that.log.error(err);
+    });
 }
 
 MiAqaraPlatform.prototype.getPromises = function(msgTag) {
@@ -437,6 +467,10 @@ MiAqaraPlatform.prototype.sendReadCommand = function(deviceSid, command, options
     var that = this;
     return new Promise((resolve, reject) => {
         var device = that.DeviceUtil.getBySid(deviceSid);
+        if (!device) {
+            reject('no such device: ' + deviceSid);
+            return;
+        }
         var gateway = that.GatewayUtil.getBySid(device.gatewaySid);
         var msgTag = 'read_' + deviceSid + "_t" + that.getPromisesTagSerialNumber();
         that.sendCommand(gateway.ip, gateway.port, msgTag, command, options).then(result => {
@@ -452,16 +486,26 @@ MiAqaraPlatform.prototype.sendWriteCommand = function(deviceSid, command, option
     var that = this;
     return new Promise((resolve, reject) => {
         var device = that.DeviceUtil.getBySid(deviceSid);
+        if (!device) {
+            reject('no such device: ' + deviceSid);
+            return;
+        }
         var gateway = that.GatewayUtil.getBySid(device.gatewaySid);
         
         var cipher = crypto.createCipheriv('aes-128-cbc', that.ConfigUtil.getGatewayPasswordByGatewaySid(gateway['sid']), iv);
         var gatewayToken = gateway['token'];
         var key = cipher.update(gatewayToken, "ascii", "hex");
         cipher.final('hex'); // Useless data, don't know why yet.
-        
-        command = command.replace('${key}', key);
+
+        if (that.isProtoVersionByGid(device.gatewaySid, 2)) {
+            command.key = key;
+            command.params = [command.data];
+            delete command.data;
+        } else {
+            command.data.key = key;
+        }
         var msgTag = 'write_' + deviceSid + "_t" + that.getPromisesTagSerialNumber();
-        that.sendCommand(gateway.ip, gateway.port, msgTag, command, options).then(result => {
+        that.sendCommand(gateway.ip, gateway.port, msgTag, JSON.stringify(command), options).then(result => {
             resolve(result);
         }).catch(function(err) {
             // that.log.error(err);
@@ -479,10 +523,17 @@ MiAqaraPlatform.prototype.sendWriteCommandWithoutFeedback = function(deviceSid, 
     var gatewayToken = gateway['token'];
     var key = cipher.update(gatewayToken, "ascii", "hex");
     cipher.final('hex'); // Useless data, don't know why yet.
-    
-    command = command.replace('${key}', key);
-    that.log.debug("[Send]" + command);
-    serverSocket.send(command, 0, command.length, gateway.port, gateway.ip, err => err && reject(err));
+
+    if (that.isProtoVersionByGid(device.gatewaySid, 2)) {
+        command.key = key;
+        command.params = [command.data];
+        delete command.data;
+    } else {
+        command.data.key = key;
+    }
+    var commandStr = JSON.stringify(command);
+    that.log.debug("[Send]" + commandStr);
+    serverSocket.send(commandStr, 0, commandStr.length, gateway.port, gateway.ip, err => err && reject(err));
 }
 
 MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {

--- a/index.js
+++ b/index.js
@@ -79,6 +79,14 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
     // accessory.reachable = true;
     if(that.AccessoryUtil) {
         if(accessory.displayName.match('TemperatureAndHumiditySensor')){
+            //SerialNumber must be unique, lets check for old SerialNumber
+            let oldSerial = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
+            if(!oldSerial.match('-')&&accessory.displayName.match('_TemperatureSensor_')){
+                oldSerial = oldSerial + '-T'
+            } else if(!oldSerial.match('-')&&accessory.displayName.match('_HumiditySensor_')){
+                oldSerial = oldSerial + '-H'
+            }
+            accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.SerialNumber, oldSerial);
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('MotionSensor')){

--- a/index.js
+++ b/index.js
@@ -84,6 +84,9 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
         } else if(accessory.displayName.match('MotionSensor')){
             accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
+        } else if(accessory.displayName.match('ContactSensor')){
+            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);
     }
@@ -550,6 +553,9 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('MotionSensor')){
             accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService.log = that.log.log;
+        } else if(accessory.displayName.match('ContactSensor')){
+            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);

--- a/index.js
+++ b/index.js
@@ -79,22 +79,25 @@ MiAqaraPlatform.prototype.configureAccessory = function(accessory) {
     // accessory.reachable = true;
     if(that.AccessoryUtil) {
         if(accessory.displayName.match('TemperatureAndHumiditySensor')){
-            //SerialNumber must be unique, lets check for old SerialNumber
-            let oldSerial = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
-            if(!oldSerial.match('-')&&accessory.displayName.match('_TemperatureSensor_')){
-                oldSerial = oldSerial + '-T'
-            } else if(!oldSerial.match('-')&&accessory.displayName.match('_HumiditySensor_')){
-                oldSerial = oldSerial + '-H'
-            }
-            accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.SerialNumber, oldSerial);
-            accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
-            accessory.context.loggingService.log = that.log.log;
+          //SerialNumber must be unique, lets check for old SerialNumber
+          let oldSerial = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
+          if(!oldSerial.match('-')&&accessory.displayName.match('_TemperatureSensor_')){
+            oldSerial = oldSerial + '-T'
+          } else if(!oldSerial.match('-')&&accessory.displayName.match('_HumiditySensor_')){
+            oldSerial = oldSerial + '-H'
+          }
+          accessory.getService(Service.AccessoryInformation).setCharacteristic(Characteristic.SerialNumber, oldSerial);
+          accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+          accessory.context.loggingService.log = that.log.log;
+          accessory.context.loggingService.subtype = oldSerial;
         } else if(accessory.displayName.match('MotionSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
-            accessory.context.loggingService.log = that.log.log;
+          accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+          accessory.context.loggingService.log = that.log.log;
+          accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         } else if(accessory.displayName.match('ContactSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
-            accessory.context.loggingService.log = that.log.log;
+          accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
+          accessory.context.loggingService.log = that.log.log;
+          accessory.context.loggingService.subtype = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.SerialNumber).value;
         }
         that.AccessoryUtil.add(accessory);
     }
@@ -560,10 +563,10 @@ MiAqaraPlatform.prototype.registerPlatformAccessories = function(accessories) {
             accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('MotionSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService = new FakeGatoHistoryService("motion",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         } else if(accessory.displayName.match('ContactSensor')){
-            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+            accessory.context.loggingService = new FakeGatoHistoryService("door",accessory,{storage:'fs',path:that.HBpath, disableTimer: false});
             accessory.context.loggingService.log = that.log.log;
         }
         that.AccessoryUtil.add(accessory);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "engines": {
     "node": ">=0.12.0",
     "homebridge": ">=0.4.1"
-  }
+  },
   "dependencies": {
     "fakegato-history": "^0.5.1",
     "moment": "^2.22.1"

--- a/package.json
+++ b/package.json
@@ -18,4 +18,8 @@
     "node": ">=0.12.0",
     "homebridge": ">=0.4.1"
   }
+  "dependencies": {
+    "fakegato-history": "^0.5.1",
+    "moment": "^2.22.1"
+  }
 }

--- a/parser/ContactSensorParser.js
+++ b/parser/ContactSensorParser.js
@@ -1,5 +1,6 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const moment = require('moment');
 
 class ContactSensorParser extends DeviceParser {
     constructor(model, platform) {
@@ -62,6 +63,12 @@ class ContactSensorContactSensorParser extends AccessoryParser {
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
             if(null != value) {
                 contactSensorStateCharacteristic.updateValue(value ? that.Characteristic.ContactSensorState.CONTACT_DETECTED : that.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+                let contactDetected = 0;
+                value ? contactDetected = 1 : contactDetected = 0;
+                accessory.context.loggingService.addEntry({
+                  time: moment().unix(),
+                  status: contactDetected
+                });
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/ContactSensorParser.js
+++ b/parser/ContactSensorParser.js
@@ -64,7 +64,7 @@ class ContactSensorContactSensorParser extends AccessoryParser {
             if(null != value) {
                 contactSensorStateCharacteristic.updateValue(value ? that.Characteristic.ContactSensorState.CONTACT_DETECTED : that.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
                 let contactDetected = 0;
-                value ? contactDetected = 1 : contactDetected = 0;
+                value ? contactDetected = 0 : contactDetected = 1;
                 accessory.context.loggingService.addEntry({
                   time: moment().unix(),
                   status: contactDetected

--- a/parser/ContactSensorParser.js
+++ b/parser/ContactSensorParser.js
@@ -1,6 +1,9 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
+const inherits = require('util').inherits;
+
+var Accessory, Service, Characteristic, PlatformAccessory;
 
 class ContactSensorParser extends DeviceParser {
     constructor(model, platform) {
@@ -21,6 +24,40 @@ module.exports = ContactSensorParser;
 class ContactSensorContactSensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        PlatformAccessory = platform.PlatformAccessory;
+        Accessory = platform.Accessory;
+        Service = platform.Service;
+        Characteristic = platform.Characteristic;
+        
+       /// /////////////////////////////////////////////////////////////////////////
+       // OpenDuration Characteristic
+       /// ///////////////////////////////////////////////////////////////////////// 
+       Characteristic.OpenDuration = function() {
+         Characteristic.call(this, 'Open Duration', 'E863F118-079E-48FF-8F27-9C2605A29F52');
+         this.setProps({
+           format: Characteristic.Formats.UINT32,
+           unit: Characteristic.Units.SECONDS,
+           perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+         });
+         this.value = this.getDefaultValue();
+       };
+       inherits(Characteristic.OpenDuration, Characteristic);
+       Characteristic.OpenDuration.UUID = 'E863F118-079E-48FF-8F27-9C2605A29F52';  
+              
+       /// /////////////////////////////////////////////////////////////////////////
+       // ClosedDuration Characteristic
+       /// ///////////////////////////////////////////////////////////////////////// 
+       Characteristic.ClosedDuration = function() {
+         Characteristic.call(this, 'Closed Duration', 'E863F119-079E-48FF-8F27-9C2605A29F52');
+         this.setProps({
+           format: Characteristic.Formats.UINT32,
+           unit: Characteristic.Units.SECONDS,
+           perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+         });
+         this.value = this.getDefaultValue();
+       };
+       inherits(Characteristic.ClosedDuration, Characteristic);
+       Characteristic.ClosedDuration.UUID = 'E863F119-079E-48FF-8F27-9C2605A29F52';  
     }
     
     getAccessoryCategory(deviceSid) {
@@ -41,6 +78,10 @@ class ContactSensorContactSensorParser extends AccessoryParser {
         
         var service = new that.Service.ContactSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.ContactSensorState);
+        service.addCharacteristic(that.Characteristic.OpenDuration);
+        service.getCharacteristic(that.Characteristic.OpenDuration);
+        service.addCharacteristic(that.Characteristic.ClosedDuration);
+        service.getCharacteristic(that.Characteristic.ClosedDuration);
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -59,7 +100,11 @@ class ContactSensorContactSensorParser extends AccessoryParser {
         var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
         if(accessory) {
             var service = accessory.getService(that.Service.ContactSensor);
-            var contactSensorStateCharacteristic = service.getCharacteristic(that.Characteristic.ContactSensorState);
+            var contactSensorStateCharacteristic = service.getCharacteristic(that.Characteristic.ContactSensorState);            
+            if(!service.testCharacteristic(that.Characteristic.OpenDuration))service.addCharacteristic(that.Characteristic.OpenDuration);
+            if(!service.testCharacteristic(that.Characteristic.ClosedDuration))service.addCharacteristic(that.Characteristic.ClosedDuration);
+            service.getCharacteristic(that.Characteristic.OpenDuration);
+            service.getCharacteristic(that.Characteristic.ClosedDuration);                        
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
             if(null != value) {
                 contactSensorStateCharacteristic.updateValue(value ? that.Characteristic.ContactSensorState.CONTACT_DETECTED : that.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -1,5 +1,6 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const moment = require('moment');
 
 class MotionSensor2Parser extends DeviceParser {
     constructor(model, platform) {
@@ -62,7 +63,13 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
             var value = that.getMotionDetectedCharacteristicValue(jsonObj, null);
             if(null != value) {
+                let motionDetected = 0;
                 motionDetectedCharacteristic.updateValue(value);
+                value ? motionDetected = 1 : motionDetected = 0;
+                accessory.context.loggingService.addEntry({
+                  time: moment().unix(),
+                  status: motionDetected
+                });
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -1,6 +1,9 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
+const inherits = require('util').inherits;
+
+var Accessory, Service, Characteristic, PlatformAccessory;
 
 class MotionSensor2Parser extends DeviceParser {
     constructor(model, platform) {
@@ -22,6 +25,25 @@ module.exports = MotionSensor2Parser;
 class MotionSensor2MotionSensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        PlatformAccessory = platform.PlatformAccessory;
+        Accessory = platform.Accessory;
+        Service = platform.Service;
+        Characteristic = platform.Characteristic;
+        
+       /// /////////////////////////////////////////////////////////////////////////
+       // LastActivation Characteristic
+       /// ///////////////////////////////////////////////////////////////////////// 
+       Characteristic.LastActivation = function() {
+         Characteristic.call(this, 'Last Activation', 'E863F11A-079E-48FF-8F27-9C2605A29F52');
+         this.setProps({
+           format: Characteristic.Formats.UINT32,
+           unit: Characteristic.Units.SECONDS,
+           perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+         });
+         this.value = this.getDefaultValue();
+       };
+       inherits(Characteristic.LastActivation, Characteristic);
+       Characteristic.LastActivation.UUID = 'E863F11A-079E-48FF-8F27-9C2605A29F52';  
     }
     
     getAccessoryCategory(deviceSid) {
@@ -42,6 +64,8 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         
         var service = new that.Service.MotionSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.MotionDetected);
+        service.addCharacteristic(that.Characteristic.LastActivation);
+        service.getCharacteristic(that.Characteristic.LastActivation);
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -60,16 +84,31 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
+            if(!service.testCharacteristic(that.Characteristic.LastActivation))service.addCharacteristic(that.Characteristic.LastActivation);
+            service.getCharacteristic(that.Characteristic.LastActivation);
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
             var value = that.getMotionDetectedCharacteristicValue(jsonObj, null);
             if(null != value) {
+                let totallength = accessory.context.loggingService.history.length - 1; 
+                let latestTime = accessory.context.loggingService.history[totallength].time;
+                let latestStatus = accessory.context.loggingService.history[totallength].status;
+                let lastActivation = 0;
                 let motionDetected = 0;
+                if(value){
+                  motionDetected = 1;
+                  lastActivation = moment().unix();
+                } else {
+                  motionDetected = 0;
+                  lastActivation = latestTime - accessory.context.loggingService.getInitialTime();
+                }
+                service.getCharacteristic(that.Characteristic.LastActivation).updateValue(lastActivation);
                 motionDetectedCharacteristic.updateValue(value);
-                value ? motionDetected = 1 : motionDetected = 0;
-                accessory.context.loggingService.addEntry({
-                  time: moment().unix(),
-                  status: motionDetected
-                });
+                if(motionDetected != latestStatus){
+                  accessory.context.loggingService.addEntry({
+                    time: moment().unix(),
+                    status: motionDetected
+                  });
+                }
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/MotionSensorParser.js
+++ b/parser/MotionSensorParser.js
@@ -1,5 +1,6 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const moment = require('moment');
 
 class MotionSensorParser extends DeviceParser {
     constructor(model, platform) {
@@ -61,7 +62,13 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
             var value = that.getMotionDetectedCharacteristicValue(jsonObj, null);
             if(null != value) {
+                let motionDetected = 0;
                 motionDetectedCharacteristic.updateValue(value);
+                value ? motionDetected = 1 : motionDetected = 0;
+                accessory.context.loggingService.addEntry({
+                  time: moment().unix(),
+                  status: motionDetected
+                });
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/MotionSensorParser.js
+++ b/parser/MotionSensorParser.js
@@ -1,6 +1,9 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
+const inherits = require('util').inherits;
+
+var Accessory, Service, Characteristic, PlatformAccessory;
 
 class MotionSensorParser extends DeviceParser {
     constructor(model, platform) {
@@ -21,6 +24,25 @@ module.exports = MotionSensorParser;
 class MotionSensorMotionSensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        PlatformAccessory = platform.PlatformAccessory;
+        Accessory = platform.Accessory;
+        Service = platform.Service;
+        Characteristic = platform.Characteristic;
+        
+       /// /////////////////////////////////////////////////////////////////////////
+       // LastActivation Characteristic
+       /// ///////////////////////////////////////////////////////////////////////// 
+       Characteristic.LastActivation = function() {
+         Characteristic.call(this, 'Last Activation', 'E863F11A-079E-48FF-8F27-9C2605A29F52');
+         this.setProps({
+           format: Characteristic.Formats.UINT32,
+           unit: Characteristic.Units.SECONDS,
+           perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+         });
+         this.value = this.getDefaultValue();
+       };
+       inherits(Characteristic.LastActivation, Characteristic);
+       Characteristic.LastActivation.UUID = 'E863F11A-079E-48FF-8F27-9C2605A29F52';  
     }
     
     getAccessoryCategory(deviceSid) {
@@ -41,6 +63,8 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
         
         var service = new that.Service.MotionSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.MotionDetected);
+        service.addCharacteristic(that.Characteristic.LastActivation);
+        service.getCharacteristic(that.Characteristic.LastActivation);
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -59,16 +83,31 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
         var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
+            if(!service.testCharacteristic(that.Characteristic.LastActivation))service.addCharacteristic(that.Characteristic.LastActivation);
+            service.getCharacteristic(that.Characteristic.LastActivation);
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
             var value = that.getMotionDetectedCharacteristicValue(jsonObj, null);
             if(null != value) {
+                let totallength = accessory.context.loggingService.history.length - 1; 
+                let latestTime = accessory.context.loggingService.history[totallength].time;
+                let latestStatus = accessory.context.loggingService.history[totallength].status;
+                let lastActivation = 0;
                 let motionDetected = 0;
+                if(value){
+                  motionDetected = 1;
+                  lastActivation = moment().unix();
+                } else {
+                  motionDetected = 0;
+                  lastActivation = latestTime - accessory.context.loggingService.getInitialTime();
+                }
+                service.getCharacteristic(that.Characteristic.LastActivation).updateValue(lastActivation);
                 motionDetectedCharacteristic.updateValue(value);
-                value ? motionDetected = 1 : motionDetected = 0;
-                accessory.context.loggingService.addEntry({
-                  time: moment().unix(),
-                  status: motionDetected
-                });
+                if(motionDetected != latestStatus){
+                  accessory.context.loggingService.addEntry({
+                    time: moment().unix(),
+                    status: motionDetected
+                  });
+                }
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -33,7 +33,7 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
         return {
             'Manufacturer': 'Aqara',
             'Model': 'Temperature And Humidity Sensor 2',
-            'SerialNumber': deviceSid
+            'SerialNumber': deviceSid + '-T'
         };
     }
 
@@ -119,7 +119,7 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
         return {
             'Manufacturer': 'Aqara',
             'Model': 'Temperature And Humidity Sensor 2',
-            'SerialNumber': deviceSid
+            'SerialNumber': deviceSid + '-H'
         };
     }
 

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -2,8 +2,6 @@ const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
 
-var FakeGatoHistoryService;
-
 class TemperatureAndHumiditySensor2Parser extends DeviceParser {
     constructor(model, platform) {
         super(model, platform);
@@ -25,8 +23,6 @@ module.exports = TemperatureAndHumiditySensor2Parser;
 class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
-        FakeGatoHistoryService = require('fakegato-history')(this.platform.api)
-        this.HBpath = this.platform.api.user.storagePath()+'/accessories';
     }
     
     getAccessoryCategory(deviceSid) {
@@ -73,6 +69,12 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
             var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentTemperatureCharacteristic.updateValue(value);
+                accessory.context.loggingService.addEntry({
+                  time: moment().unix(),
+                  temp: value,
+                  pressure: 0,
+                  humidity: 0
+                });
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {
@@ -95,7 +97,6 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
             }
             
             that.parserBatteryService(accessory, jsonObj);
-            that.getTempHistory(jsonObj, null);
         }
     }
     
@@ -103,33 +104,11 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
         var value = this.getValueFrJsonObjData(jsonObj, 'temperature');
         return (null != value) ? (value / 100.0) : defaultValue;
     }
-    
-    getTempHistory(jsonObj, defaultValue){
-	    var that = this;
-        var deviceSid = jsonObj['sid'];
-        var uuid = that.getAccessoryUUID(deviceSid);
-	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
-	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Temperature.json'});
-		  accessory.context.loggingService.log = that.platform.log.log;
-  	      var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
-	      if(null != value){
-            accessory.context.loggingService.addEntry({
-              time: moment().unix(),
-              temp: value,
-              pressure: 0,
-              humidity: 0
-            });
-	      }
-	    }
-    }
 }
 
 class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
-        FakeGatoHistoryService = require('fakegato-history')(this.platform.api)
-        this.HBpath = this.platform.api.user.storagePath()+'/accessories';
     }
     
     getAccessoryCategory(deviceSid) {
@@ -172,6 +151,12 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentRelativeHumidityCharacteristic.updateValue(value);
+                accessory.context.loggingService.addEntry({
+                  time: moment().unix(),
+                  temp: 0,
+                  pressure: 0,
+                  humidity: value
+                });
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {
@@ -194,33 +179,12 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             }
             
             that.parserBatteryService(accessory, jsonObj);
-            that.getHumidityHistory(jsonObj, null);
         }
     }
     
     getCurrentRelativeHumidityCharacteristicValue(jsonObj, defaultValue) {
         var value = this.getValueFrJsonObjData(jsonObj, 'humidity');
         return (null != value) ? (value / 100.0) : defaultValue;
-    }
-    
-    getHumidityHistory(jsonObj, defaultValue){
-	    var that = this;
-        var deviceSid = jsonObj['sid'];
-        var uuid = that.getAccessoryUUID(deviceSid);
-	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
-	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Humidity.json'});
-		  accessory.context.loggingService.log = that.platform.log.log;
-  	      var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
-	      if(null != value){
-            accessory.context.loggingService.addEntry({
-              time: moment().unix(),
-              temp: 0,
-              pressure: 0,
-              humidity: value
-            });
-	      }
-	    }
     }
 }
 /*

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -110,7 +110,7 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
         var uuid = that.getAccessoryUUID(deviceSid);
 	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
 	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Temperature.json'});
 		  accessory.context.loggingService.log = that.platform.log.log;
   	      var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
 	      if(null != value){
@@ -131,6 +131,8 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
 class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        FakeGatoHistoryService = require('fakegato-history')(this.platform.api)
+        this.HBpath = this.platform.api.user.storagePath()+'/accessories';
     }
     
     getAccessoryCategory(deviceSid) {
@@ -210,7 +212,7 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
         var uuid = that.getAccessoryUUID(deviceSid);
 	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
 	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Humidity.json'});
 		  accessory.context.loggingService.log = that.platform.log.log;
   	      var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
 	      if(null != value){

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -122,9 +122,6 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
             });
 	      }
 	    }
-	    setTimeout(function(){
-		    that.getTempHistory(jsonObj, defaultValue);
-	    }, 8 * 60 * 1000) //8min
     }
 }
 
@@ -224,9 +221,6 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             });
 	      }
 	    }
-	    setTimeout(function(){
-		    that.getHumidityHistory(jsonObj, defaultValue);
-	    }, 8 * 60 * 1000) //8min
     }
 }
 /*

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -1,5 +1,8 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const moment = require('moment');
+
+var FakeGatoHistoryService;
 
 class TemperatureAndHumiditySensor2Parser extends DeviceParser {
     constructor(model, platform) {
@@ -22,6 +25,8 @@ module.exports = TemperatureAndHumiditySensor2Parser;
 class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        FakeGatoHistoryService = require('fakegato-history')(this.platform.api)
+        this.HBpath = this.platform.api.user.storagePath()+'/accessories';
     }
     
     getAccessoryCategory(deviceSid) {
@@ -90,12 +95,36 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
             }
             
             that.parserBatteryService(accessory, jsonObj);
+            that.getTempHistory(jsonObj, null);
         }
     }
     
     getCurrentTemperatureCharacteristicValue(jsonObj, defaultValue) {
         var value = this.getValueFrJsonObjData(jsonObj, 'temperature');
         return (null != value) ? (value / 100.0) : defaultValue;
+    }
+    
+    getTempHistory(jsonObj, defaultValue){
+	    var that = this;
+        var deviceSid = jsonObj['sid'];
+        var uuid = that.getAccessoryUUID(deviceSid);
+	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
+	    if(accessory){
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService.log = that.platform.log.log;
+  	      var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
+	      if(null != value){
+            accessory.context.loggingService.addEntry({
+              time: moment().unix(),
+              temp: value,
+              pressure: 0,
+              humidity: 0
+            });
+	      }
+	    }
+	    setTimeout(function(){
+		    that.getTempHistory(jsonObj, defaultValue);
+	    }, 8 * 60 * 1000) //8min
     }
 }
 
@@ -166,12 +195,36 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             }
             
             that.parserBatteryService(accessory, jsonObj);
+            that.getHumidityHistory(jsonObj, null);
         }
     }
     
     getCurrentRelativeHumidityCharacteristicValue(jsonObj, defaultValue) {
         var value = this.getValueFrJsonObjData(jsonObj, 'humidity');
         return (null != value) ? (value / 100.0) : defaultValue;
+    }
+    
+    getHumidityHistory(jsonObj, defaultValue){
+	    var that = this;
+        var deviceSid = jsonObj['sid'];
+        var uuid = that.getAccessoryUUID(deviceSid);
+	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
+	    if(accessory){
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService.log = that.platform.log.log;
+  	      var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
+	      if(null != value){
+            accessory.context.loggingService.addEntry({
+              time: moment().unix(),
+              temp: 0,
+              pressure: 0,
+              humidity: value
+            });
+	      }
+	    }
+	    setTimeout(function(){
+		    that.getHumidityHistory(jsonObj, defaultValue);
+	    }, 8 * 60 * 1000) //8min
     }
 }
 /*

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -109,7 +109,7 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
         var uuid = that.getAccessoryUUID(deviceSid);
 	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
 	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Temperature.json'});
 		  accessory.context.loggingService.log = that.platform.log.log;
   	      var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
 	      if(null != value){
@@ -130,6 +130,8 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
 class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
     constructor(model, platform, accessoryType) {
         super(model, platform, accessoryType)
+        FakeGatoHistoryService = require('fakegato-history')(this.platform.api)
+        this.HBpath = this.platform.api.user.storagePath()+'/accessories';
     }
     
     getAccessoryCategory(deviceSid) {
@@ -209,7 +211,7 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
         var uuid = that.getAccessoryUUID(deviceSid);
 	    var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
 	    if(accessory){
-		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true});
+		  accessory.context.loggingService = new FakeGatoHistoryService("weather",accessory,{storage:'fs',path:that.HBpath, disableTimer: true, filename: accessory.displayName + '_Humidity.json'});
 		  accessory.context.loggingService.log = that.platform.log.log;
   	      var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
 	      if(null != value){

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -32,7 +32,7 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
         return {
             'Manufacturer': 'Aqara',
             'Model': 'Temperature And Humidity Sensor',
-            'SerialNumber': deviceSid
+            'SerialNumber': deviceSid + '-T'
         };
     }
 
@@ -118,7 +118,7 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
         return {
             'Manufacturer': 'Aqara',
             'Model': 'Temperature And Humidity Sensor',
-            'SerialNumber': deviceSid
+            'SerialNumber': deviceSid + '-H'
         };
     }
 

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -121,9 +121,6 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
             });
 	      }
 	    }
-	    setTimeout(function(){
-		    that.getTempHistory(jsonObj, defaultValue);
-	    }, 8 * 60 * 1000) //8min
     }
 }
 
@@ -223,8 +220,5 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
             });
 	      }
 	    }
-	    setTimeout(function(){
-		    that.getHumidityHistory(jsonObj, defaultValue);
-	    }, 8 * 60 * 1000) //8min
     }
 }


### PR DESCRIPTION
Fakegato is a module to emulate Elgato Eve history service in Homebridge accessories, so that it will show in Eve.app

Fakegato: https://github.com/simont77/fakegato-history/blob/master/README.md

This will add Fakegato to Temperature/Humidity Sensors (v1/v2), Motion Sensors (v1/v2) and Contact Sensors 

If you do not want to wait for this pull request, you can already install the version with 'Fakegato' as follows

sudo npm i -g homebridge-mi-aqara-fakegato