### PR TITLE
FakeGato Support - v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,8 @@ mv cachedAccessories cachedAccessories_\`date '+%Y%m%d_%H%M%S'\`.bak
 echo [] > cachedAccessories   
 
 ## Version Logs
+### 0.8.1 (2019-04-28)
+1. add fakegato-history. 
 ### 0.8.0 (2018-11-04)
 1. add mqtt support.   
 ### 0.7.3 (2018-10-27)

--- a/lib/EveUtil.js
+++ b/lib/EveUtil.js
@@ -1,0 +1,366 @@
+'use strict';
+
+const inherits = require('util').inherits;
+
+module.exports = {
+  registerWith: function (hap) {
+    const Characteristic = hap.Characteristic;
+    const Service = hap.Service;
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Sensitivity
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.Sensitivity = function() {
+      Characteristic.call(this, 'Sensitivity', 'E863F120-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT8,
+        minValue: 0,
+        maxValue: 7,
+        validValues: [0, 4, 7],
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.Sensitivity, Characteristic);
+    Characteristic.Sensitivity.UUID = 'E863F120-079E-48FF-8F27-9C2605A29F52';
+    
+    Characteristic.Sensitivity.HIGH = 0;
+    Characteristic.Sensitivity.MEDIUM = 4;
+    Characteristic.Sensitivity.LOW = 7;
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Duration
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.Duration = function() {
+      Characteristic.call(this, 'Duration', 'E863F12D-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT16,
+        unit: Characteristic.Units.SECONDS,
+        minValue: 5,
+        maxValue: 15 * 3600,
+        validValues: [
+          5, 10, 20, 30,
+          1 * 60, 2 * 60, 3 * 60, 5 * 60, 10 * 60, 20 * 60, 30 * 60,
+          1 * 3600, 2 * 3600, 3 * 3600, 5 * 3600, 10 * 3600, 12 * 3600, 15 * 3600
+        ],
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.Duration, Characteristic);
+    Characteristic.Duration.UUID = 'E863F12D-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // ResetTotal
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.ResetTotal = function() {
+      Characteristic.call(this, 'Reset Total', 'E863F112-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT32,
+        unit: Characteristic.Units.SECONDS,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.ResetTotal, Characteristic);
+    Characteristic.ResetTotal.UUID = 'E863F112-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // HistoryStatus
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.HistoryStatus = function() {
+      Characteristic.call(this, 'History Status', 'E863F116-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.DATA,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.HistoryStatus, Characteristic);
+    Characteristic.HistoryStatus.UUID = 'E863F116-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // HistoryEntries
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.HistoryEntries = function() {
+      Characteristic.call(this, 'History Entries', 'E863F117-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.DATA,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.HistoryEntries, Characteristic);
+    Characteristic.HistoryEntries.UUID = 'E863F117-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // HistoryRequest
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.HistoryRequest = function() {
+      Characteristic.call(this, 'History Request', 'E863F11C-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.DATA,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.HistoryRequest, Characteristic);
+    Characteristic.HistoryRequest.UUID = 'E863F11C-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // SetTime
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.SetTime = function() {
+      Characteristic.call(this, 'Set Time', 'E863F121-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.DATA,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.SetTime, Characteristic);
+    Characteristic.SetTime.UUID = 'E863F121-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // LastActivation
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.LastActivation = function() {
+      Characteristic.call(this, 'Last Activation', 'E863F11A-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT32,
+        unit: Characteristic.Units.SECONDS,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.LastActivation, Characteristic);
+    Characteristic.LastActivation.UUID = 'E863F11A-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // TimesOpened
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.TimesOpened = function() {
+      Characteristic.call(this, 'Times Opened', 'E863F129-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT32,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.TimesOpened, Characteristic);
+    Characteristic.TimesOpened.UUID = 'E863F129-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // OpenDuration
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.OpenDuration = function() {
+      Characteristic.call(this, 'Open Duration', 'E863F118-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT32,
+        unit: Characteristic.Units.SECONDS,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.OpenDuration, Characteristic);
+    Characteristic.OpenDuration.UUID = 'E863F118-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // ClosedDuration
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.ClosedDuration = function() {
+      Characteristic.call(this, 'Closed Duration', 'E863F119-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT32,
+        unit: Characteristic.Units.SECONDS,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.ClosedDuration, Characteristic);
+    Characteristic.ClosedDuration.UUID = 'E863F119-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // PowerConsumption
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.PowerConsumption = function() {
+      Characteristic.call(this, 'Consumption', 'E863F10D-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT16,
+        unit: 'watts',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 1,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.PowerConsumption, Characteristic);
+    Characteristic.PowerConsumption.UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // PowerConsumptionVA
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.PowerConsumptionVA = function() {
+      Characteristic.call(this, 'Consumption VA', 'E863F110-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT16,
+        unit: 'volt-amperes',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 1,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.PowerConsumptionVA, Characteristic);
+    Characteristic.PowerConsumptionVA.UUID = 'E863F110-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // TotalPowerConsumption
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.TotalPowerConsumption = function() {
+      Characteristic.call(this, 'Total Consumption', 'E863F10C-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: 'kilowatthours',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 0.001,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.TotalPowerConsumption, Characteristic);
+    Characteristic.TotalPowerConsumption.UUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // TotalPowerConsumptionVA
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.TotalPowerConsumptionVA = function() {
+      Characteristic.call(this, 'Total Consumption VA', 'E863F127-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: 'kilovolt-ampereshours',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 0.001,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.TotalPowerConsumptionVA, Characteristic);
+    Characteristic.TotalPowerConsumptionVA.UUID = 'E863F127-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Volts
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.Volts = function() {
+      Characteristic.call(this, 'Volts', 'E863F10A-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT16,
+        unit: 'volts',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 1,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.Volts, Characteristic);
+    Characteristic.Volts.UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Amperes
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Characteristic.Amperes = function() {
+      Characteristic.call(this, 'Amperes', 'E863F126-079E-48FF-8F27-9C2605A29F52');
+      this.setProps({
+        format: Characteristic.Formats.UINT16,
+        unit: 'amperes',
+        maxValue: 1000000000,
+        minValue: 0,
+        minStep: 0.001,
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    inherits(Characteristic.Amperes, Characteristic);
+    Characteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
+
+    /// /////////////////////////////////////////////////////////////////////////
+    // ContactSensor
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Service.ContactSensor = function(displayName, subtype) {
+      Service.call(this, displayName, '00000080-0000-1000-8000-0026BB765291', subtype);
+      // Required Characteristics
+      this.addCharacteristic(Characteristic.ContactSensorState);
+
+      //EVE
+      this.addCharacteristic(Characteristic.TimesOpened);
+      this.addCharacteristic(Characteristic.OpenDuration);
+      this.addCharacteristic(Characteristic.ClosedDuration);
+      this.addCharacteristic(Characteristic.LastActivation);
+
+      // Optional Characteristics
+      this.addOptionalCharacteristic(Characteristic.StatusActive);
+      this.addOptionalCharacteristic(Characteristic.StatusFault);
+      this.addOptionalCharacteristic(Characteristic.StatusTampered);
+      this.addOptionalCharacteristic(Characteristic.StatusLowBattery);
+      this.addOptionalCharacteristic(Characteristic.Name);
+    };
+    inherits(Service.ContactSensor, Service);
+    Service.ContactSensor.UUID = '00000080-0000-1000-8000-0026BB765291';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // Outlet
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Service.Outlet = function(displayName, subtype) {
+      Service.call(this, displayName, '00000047-0000-1000-8000-0026BB765291', subtype);
+      
+      // Required Characteristics
+      this.addCharacteristic(Characteristic.On);
+      this.addCharacteristic(Characteristic.OutletInUse);
+
+      //EVE
+      this.addOptionalCharacteristic(Characteristic.PowerConsumption);
+      this.addOptionalCharacteristic(Characteristic.PowerConsumptionVA);
+      this.addOptionalCharacteristic(Characteristic.TotalPowerConsumption);
+      this.addOptionalCharacteristic(Characteristic.TotalPowerConsumptionVA);
+      this.addOptionalCharacteristic(Characteristic.Volts);
+      this.addOptionalCharacteristic(Characteristic.Amperes);
+
+      // Optional Characteristics
+      this.addOptionalCharacteristic(Characteristic.Name);
+    
+    };
+    inherits(Service.Outlet, Service);
+    Service.Outlet.UUID = '00000047-0000-1000-8000-0026BB765291';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // MotionSensor
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Service.MotionSensor = function(displayName, subtype) {
+      Service.call(this, displayName, '00000085-0000-1000-8000-0026BB765291', subtype);
+      
+      // Required Characteristics
+      this.addCharacteristic(Characteristic.MotionDetected);
+
+      //EVE
+      this.addOptionalCharacteristic(Characteristic.Duration);
+      this.addOptionalCharacteristic(Characteristic.LastActivation);
+      this.addOptionalCharacteristic(Characteristic.Sensitivity);
+
+      // Optional Characteristics
+      this.addOptionalCharacteristic(Characteristic.StatusActive);
+      this.addOptionalCharacteristic(Characteristic.StatusFault);
+      this.addOptionalCharacteristic(Characteristic.StatusTampered);
+      this.addOptionalCharacteristic(Characteristic.StatusLowBattery);
+      this.addOptionalCharacteristic(Characteristic.Name);
+    
+    };
+    inherits(Service.MotionSensor, Service);
+    Service.MotionSensor.UUID = '00000085-0000-1000-8000-0026BB765291';
+
+  }
+};

--- a/lib/EveUtil.js
+++ b/lib/EveUtil.js
@@ -287,30 +287,6 @@ module.exports = {
     };
     inherits(Characteristic.Amperes, Characteristic);
     Characteristic.Amperes.UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
-
-    /// /////////////////////////////////////////////////////////////////////////
-    // ContactSensor
-    /// ///////////////////////////////////////////////////////////////////////// 
-    Service.ContactSensor = function(displayName, subtype) {
-      Service.call(this, displayName, '00000080-0000-1000-8000-0026BB765291', subtype);
-      // Required Characteristics
-      this.addCharacteristic(Characteristic.ContactSensorState);
-
-      //EVE
-      this.addCharacteristic(Characteristic.TimesOpened);
-      this.addCharacteristic(Characteristic.OpenDuration);
-      this.addCharacteristic(Characteristic.ClosedDuration);
-      this.addCharacteristic(Characteristic.LastActivation);
-
-      // Optional Characteristics
-      this.addOptionalCharacteristic(Characteristic.StatusActive);
-      this.addOptionalCharacteristic(Characteristic.StatusFault);
-      this.addOptionalCharacteristic(Characteristic.StatusTampered);
-      this.addOptionalCharacteristic(Characteristic.StatusLowBattery);
-      this.addOptionalCharacteristic(Characteristic.Name);
-    };
-    inherits(Service.ContactSensor, Service);
-    Service.ContactSensor.UUID = '00000080-0000-1000-8000-0026BB765291';
     
     /// /////////////////////////////////////////////////////////////////////////
     // Outlet
@@ -347,9 +323,9 @@ module.exports = {
       this.addCharacteristic(Characteristic.MotionDetected);
 
       //EVE
-      this.addOptionalCharacteristic(Characteristic.Duration);
-      this.addOptionalCharacteristic(Characteristic.LastActivation);
-      this.addOptionalCharacteristic(Characteristic.Sensitivity);
+      this.addCharacteristic(Characteristic.Duration);
+      this.addCharacteristic(Characteristic.LastActivation);
+      this.addCharacteristic(Characteristic.Sensitivity);
 
       // Optional Characteristics
       this.addOptionalCharacteristic(Characteristic.StatusActive);
@@ -361,6 +337,30 @@ module.exports = {
     };
     inherits(Service.MotionSensor, Service);
     Service.MotionSensor.UUID = '00000085-0000-1000-8000-0026BB765291';
+    
+    /// /////////////////////////////////////////////////////////////////////////
+    // ContactSensor
+    /// ///////////////////////////////////////////////////////////////////////// 
+    Service.ContactSensor = function(displayName, subtype) {
+      Service.call(this, displayName, '00000080-0000-1000-8000-0026BB765291', subtype);
+      // Required Characteristics
+      this.addCharacteristic(Characteristic.ContactSensorState);
+
+      //EVE
+      this.addCharacteristic(Characteristic.TimesOpened);
+      this.addCharacteristic(Characteristic.OpenDuration);
+      this.addCharacteristic(Characteristic.ClosedDuration);
+      this.addCharacteristic(Characteristic.LastActivation);
+
+      // Optional Characteristics
+      this.addOptionalCharacteristic(Characteristic.StatusActive);
+      this.addOptionalCharacteristic(Characteristic.StatusFault);
+      this.addOptionalCharacteristic(Characteristic.StatusTampered);
+      this.addOptionalCharacteristic(Characteristic.StatusLowBattery);
+      this.addOptionalCharacteristic(Characteristic.Name);
+    };
+    inherits(Service.ContactSensor, Service);
+    Service.ContactSensor.UUID = '00000080-0000-1000-8000-0026BB765291';
 
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-mi-aqara",
+  "name": "homebridge-mi-aqara-fakegato",
   "version": "0.8.0", 
   "description": "XiaoMi Aqara plugins for HomeBridge(https://github.com/nfarina/homebridge).",
   "license": "GPL",
@@ -22,6 +22,8 @@
     "body-parser": "1.18.3",
     "express": "4.16.3",
     "express-session": "1.15.6",
-    "mqtt": "2.18.0"
+    "mqtt": "2.18.0",
+    "fakegato-history": "0.5.3",
+    "moment": "2.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-mi-aqara-fakegato",
+  "name": "homebridge-mi-aqara",
   "version": "0.8.1", 
   "description": "XiaoMi Aqara plugins for HomeBridge(https://github.com/nfarina/homebridge).",
   "license": "GPL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mi-aqara-fakegato",
-  "version": "0.8.0", 
+  "version": "0.8.1", 
   "description": "XiaoMi Aqara plugins for HomeBridge(https://github.com/nfarina/homebridge).",
   "license": "GPL",
   "keywords": [

--- a/parser/ContactSensor2Parser.js
+++ b/parser/ContactSensor2Parser.js
@@ -49,6 +49,12 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
         
         var service = new that.Service.ContactSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.ContactSensorState);
+        
+        service.addCharacteristic(that.Characteristic.LastActivation);
+        service.addCharacteristic(that.Characteristic.TimesOpened);
+        service.addCharacteristic(that.Characteristic.OpenDuration);
+        service.addCharacteristic(that.Characteristic.ClosedDuration);
+        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -69,24 +75,11 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
             var service = accessory.getService(that.Service.ContactSensor);
             var contactSensorStateCharacteristic = service.getCharacteristic(that.Characteristic.ContactSensorState);
             
-            if(!service.testCharacteristic(that.Characteristic.LastActivation))
-              service.addCharacteristic(that.Characteristic.LastActivation);
-              
-            if(!service.testCharacteristic(that.Characteristic.TimesOpened))
-              service.addCharacteristic(that.Characteristic.TimesOpened);
-              
-            if(!service.testCharacteristic(that.Characteristic.OpenDuration))
-              service.addCharacteristic(that.Characteristic.OpenDuration);
-              
-            if(!service.testCharacteristic(that.Characteristic.ClosedDuration))
-              service.addCharacteristic(that.Characteristic.ClosedDuration);
-            
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
             
             if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             } 
@@ -98,10 +91,8 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
                 
                 if(value && !accessory.context.cacheValue){
                 
-                  accessory.context.timesOpened = accessory.context.timesOpened ? accessory.context.timesOpened : 0;
-                  
-                  accessory.context.timesOpened += 1;
-                
+                  accessory.context.timesOpened = accessory.context.timesOpened ? accessory.context.timesOpened : 0;                  
+                  accessory.context.timesOpened += 1;                
                   accessory.context.cacheValue = true;
                   
                   let lastActivation = moment().unix() - history[accessory.displayName].getInitialTime();          

--- a/parser/ContactSensor2Parser.js
+++ b/parser/ContactSensor2Parser.js
@@ -3,6 +3,8 @@ const AccessoryParser = require('./AccessoryParser');
 const EveUtil = require('../lib/EveUtil.js');
 const moment = require('moment');
 
+const history = [];
+
 class ContactSensor2Parser extends DeviceParser {
     constructor(platform) {
         super(platform);
@@ -81,11 +83,13 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
             
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
             
-            if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
-
-            this.historyService = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              this.historyService.log = this.log;
-            }
+            if(!history[accessory.displayName]){
+            
+              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              
+              history[accessory.displayName].log = this.log;
+          
+            } 
             
             if(null != value) {
                 contactSensorStateCharacteristic.updateValue(value ? that.Characteristic.ContactSensorState.CONTACT_DETECTED : that.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
@@ -100,8 +104,8 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
                 
                   accessory.context.cacheValue = true;
                   
-                  let lastActivation = moment().unix() - this.historyService.getInitialTime();          
-                  let closeDuration = moment().unix() - this.historyService.getInitialTime();
+                  let lastActivation = moment().unix() - history[accessory.displayName].getInitialTime();          
+                  let closeDuration = moment().unix() - history[accessory.displayName].getInitialTime();
                 
                   service.getCharacteristic(that.Characteristic.LastActivation)
                     .updateValue(lastActivation);
@@ -117,13 +121,13 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
                 if(!value && accessory.context.cacheValue){
                   accessory.context.cacheValue = false;
                   
-                  let openDuration = moment().unix() - this.historyService.getInitialTime();
+                  let openDuration = moment().unix() - history[accessory.displayName].getInitialTime();
                   
                   service.getCharacteristic(that.Characteristic.OpenDuration)
                     .updateValue(openDuration);
                 }
                 
-                this.historyService.addEntry({time: moment().unix(), status:value});
+                history[accessory.displayName].addEntry({time: moment().unix(), status:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/ContactSensor2Parser.js
+++ b/parser/ContactSensor2Parser.js
@@ -1,5 +1,7 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const EveUtil = require('../lib/EveUtil.js');
+const moment = require('moment');
 
 class ContactSensor2Parser extends DeviceParser {
     constructor(platform) {
@@ -18,6 +20,13 @@ module.exports = ContactSensor2Parser;
 class ContactSensor2ContactSensorParser extends AccessoryParser {
     constructor(platform, accessoryType) {
         super(platform, accessoryType)
+        
+        this.FakeGatoHistoryService = require('fakegato-history')(platform.api);        
+        this.HBpath = platform.api.user.storagePath()+'/accessories';
+        this.log = platform.log.log
+        
+        //EVE
+        EveUtil.registerWith(platform.api.hap);
     }
     
     getAccessoryCategory(deviceSid) {
@@ -57,9 +66,64 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
         if(accessory) {
             var service = accessory.getService(that.Service.ContactSensor);
             var contactSensorStateCharacteristic = service.getCharacteristic(that.Characteristic.ContactSensorState);
+            
+            if(!service.testCharacteristic(that.Characteristic.LastActivation))
+              service.addCharacteristic(that.Characteristic.LastActivation);
+              
+            if(!service.testCharacteristic(that.Characteristic.TimesOpened))
+              service.addCharacteristic(that.Characteristic.TimesOpened);
+              
+            if(!service.testCharacteristic(that.Characteristic.OpenDuration))
+              service.addCharacteristic(that.Characteristic.OpenDuration);
+              
+            if(!service.testCharacteristic(that.Characteristic.ClosedDuration))
+              service.addCharacteristic(that.Characteristic.ClosedDuration);
+            
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
+            
+            if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
+
+            this.historyService = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              this.historyService.log = this.log;
+            }
+            
             if(null != value) {
                 contactSensorStateCharacteristic.updateValue(value ? that.Characteristic.ContactSensorState.CONTACT_DETECTED : that.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+                
+                value = value ? 0 : 1;
+                
+                if(value && !accessory.context.cacheValue){
+                
+                  accessory.context.timesOpened = accessory.context.timesOpened ? accessory.context.timesOpened : 0;
+                  
+                  accessory.context.timesOpened += 1;
+                
+                  accessory.context.cacheValue = true;
+                  
+                  let lastActivation = moment().unix() - this.historyService.getInitialTime();          
+                  let closeDuration = moment().unix() - this.historyService.getInitialTime();
+                
+                  service.getCharacteristic(that.Characteristic.LastActivation)
+                    .updateValue(lastActivation);
+                  
+                  service.getCharacteristic(that.Characteristic.ClosedDuration)
+                    .updateValue(closeDuration);
+                  
+                  service.getCharacteristic(that.Characteristic.TimesOpened)
+                    .updateValue(accessory.context.timesOpened);
+                
+                }
+                
+                if(!value && accessory.context.cacheValue){
+                  accessory.context.cacheValue = false;
+                  
+                  let openDuration = moment().unix() - this.historyService.getInitialTime();
+                  
+                  service.getCharacteristic(that.Characteristic.OpenDuration)
+                    .updateValue(openDuration);
+                }
+                
+                this.historyService.addEntry({time: moment().unix(), status:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/ContactSensor2Parser.js
+++ b/parser/ContactSensor2Parser.js
@@ -49,12 +49,6 @@ class ContactSensor2ContactSensorParser extends AccessoryParser {
         
         var service = new that.Service.ContactSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.ContactSensorState);
-        
-        service.addCharacteristic(that.Characteristic.LastActivation);
-        service.addCharacteristic(that.Characteristic.TimesOpened);
-        service.addCharacteristic(that.Characteristic.OpenDuration);
-        service.addCharacteristic(that.Characteristic.ClosedDuration);
-        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);

--- a/parser/ContactSensorParser.js
+++ b/parser/ContactSensorParser.js
@@ -49,12 +49,6 @@ class ContactSensorContactSensorParser extends AccessoryParser {
         
         var service = new that.Service.ContactSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.ContactSensorState);
-        
-        service.addCharacteristic(that.Characteristic.LastActivation);
-        service.addCharacteristic(that.Characteristic.TimesOpened);
-        service.addCharacteristic(that.Characteristic.OpenDuration);
-        service.addCharacteristic(that.Characteristic.ClosedDuration);
-        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);

--- a/parser/ContactSensorParser.js
+++ b/parser/ContactSensorParser.js
@@ -49,6 +49,12 @@ class ContactSensorContactSensorParser extends AccessoryParser {
         
         var service = new that.Service.ContactSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.ContactSensorState);
+        
+        service.addCharacteristic(that.Characteristic.LastActivation);
+        service.addCharacteristic(that.Characteristic.TimesOpened);
+        service.addCharacteristic(that.Characteristic.OpenDuration);
+        service.addCharacteristic(that.Characteristic.ClosedDuration);
+        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -69,24 +75,11 @@ class ContactSensorContactSensorParser extends AccessoryParser {
             var service = accessory.getService(that.Service.ContactSensor);
             var contactSensorStateCharacteristic = service.getCharacteristic(that.Characteristic.ContactSensorState);
             
-            if(!service.testCharacteristic(that.Characteristic.LastActivation))
-              service.addCharacteristic(that.Characteristic.LastActivation);
-              
-            if(!service.testCharacteristic(that.Characteristic.TimesOpened))
-              service.addCharacteristic(that.Characteristic.TimesOpened);
-              
-            if(!service.testCharacteristic(that.Characteristic.OpenDuration))
-              service.addCharacteristic(that.Characteristic.OpenDuration);
-              
-            if(!service.testCharacteristic(that.Characteristic.ClosedDuration))
-              service.addCharacteristic(that.Characteristic.ClosedDuration);
-            
             var value = that.getContactSensorStateCharacteristicValue(jsonObj, null);
             
             if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});             
               history[accessory.displayName].log = this.log;
           
             } 
@@ -98,10 +91,8 @@ class ContactSensorContactSensorParser extends AccessoryParser {
                 
                 if(value && !accessory.context.cacheValue){
                 
-                  accessory.context.timesOpened = accessory.context.timesOpened ? accessory.context.timesOpened : 0;
-                  
-                  accessory.context.timesOpened += 1;
-                
+                  accessory.context.timesOpened = accessory.context.timesOpened ? accessory.context.timesOpened : 0;                  
+                  accessory.context.timesOpened += 1;                
                   accessory.context.cacheValue = true;
                   
                   let lastActivation = moment().unix() - history[accessory.displayName].getInitialTime();          

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -80,7 +80,7 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
             
            if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('motion', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             } 

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -111,6 +111,8 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
                 
                 if(!value)
                   this.cacheValue = false;
+                  
+                value = value ? 1 : 0;
                 
                 this.historyService.addEntry({time: moment().unix(), status:value});
             }

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -52,11 +52,6 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         
         var service = new that.Service.MotionSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.MotionDetected);
-        
-        service.addCharacteristic(that.Characteristic.LastActivation);
-        service.addCharacteristic(that.Characteristic.Sensitivity);
-        service.addCharacteristic(that.Characteristic.Duration);
-        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -75,6 +70,7 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
+            
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
             var sensitivityCharacteristic = service.getCharacteristic(that.Characteristic.Sensitivity);              
             var durationCharacteristic = service.getCharacteristic(that.Characteristic.Duration);

--- a/parser/MotionSensor2Parser.js
+++ b/parser/MotionSensor2Parser.js
@@ -52,6 +52,11 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         
         var service = new that.Service.MotionSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.MotionDetected);
+        
+        service.addCharacteristic(that.Characteristic.LastActivation);
+        service.addCharacteristic(that.Characteristic.Sensitivity);
+        service.addCharacteristic(that.Characteristic.Duration);
+        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -71,30 +76,15 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
+            var sensitivityCharacteristic = service.getCharacteristic(that.Characteristic.Sensitivity);              
+            var durationCharacteristic = service.getCharacteristic(that.Characteristic.Duration);
             
-            if(!service.testCharacteristic(that.Characteristic.LastActivation))
-              service.addCharacteristic(that.Characteristic.LastActivation);
-              
-            if(!service.testCharacteristic(that.Characteristic.Sensitivity))
-              service.addCharacteristic(that.Characteristic.Sensitivity);
-              
-            service.getCharacteristic(that.Characteristic.Sensitivity)
-              .on('get', callback => callback(null, 0))
-              .on('set', (value, callback) => callback())
-              .updateValue(0);
-              
-            if(!service.testCharacteristic(that.Characteristic.Duration))
-              service.addCharacteristic(that.Characteristic.Duration);
-              
-            service.getCharacteristic(that.Characteristic.Duration)
-              .on('get', callback => callback(null, 5))
-              .on('set', (value, callback) => callback())
-              .updateValue(5);
+            sensitivityCharacteristic.updateValue(0);
+            durationCharacteristic.updateValue(5);
             
            if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('door', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             } 
@@ -115,6 +105,8 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
                 
                 if(!value)
                   this.cacheValue = false;
+                  
+                value = value ? 1 : 0;
                 
                 history[accessory.displayName].addEntry({time: moment().unix(), status:value});
             }
@@ -136,6 +128,23 @@ class MotionSensor2MotionSensorParser extends AccessoryParser {
                         });
                     });
                 }
+                
+                if (sensitivityCharacteristic.listeners('get').length == 0) {
+                    sensitivityCharacteristic.on('get', callback => callback(null, 0));
+                }
+                
+                if (sensitivityCharacteristic.listeners('set').length == 0) {
+                    sensitivityCharacteristic.on('set', (value, callback) => callback());
+                }
+                
+                if (durationCharacteristic.listeners('get').length == 0) {
+                    durationCharacteristic.on('get', callback => callback(null, 5));
+                }
+                
+                if (durationCharacteristic.listeners('set').length == 0) {
+                    durationCharacteristic.on('set', (value, callback) => callback());
+                }
+                
             }
             
             that.parserBatteryService(accessory, jsonObj);

--- a/parser/MotionSensorParser.js
+++ b/parser/MotionSensorParser.js
@@ -1,5 +1,7 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const EveUtil = require('../lib/EveUtil.js');
+const moment = require('moment');
 
 class MotionSensorParser extends DeviceParser {
     constructor(platform) {
@@ -18,6 +20,14 @@ module.exports = MotionSensorParser;
 class MotionSensorMotionSensorParser extends AccessoryParser {
     constructor(platform, accessoryType) {
         super(platform, accessoryType)
+        
+        this.FakeGatoHistoryService = require('fakegato-history')(platform.api);        
+        this.HBpath = platform.api.user.storagePath()+'/accessories';
+        this.log = platform.log.log
+        
+        //EVE
+        EveUtil.registerWith(platform.api.hap);
+        
     }
     
     getAccessoryCategory(deviceSid) {
@@ -57,9 +67,50 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);
+            
+            if(!service.testCharacteristic(that.Characteristic.LastActivation))
+              service.addCharacteristic(that.Characteristic.LastActivation);
+              
+            if(!service.testCharacteristic(that.Characteristic.Sensitivity))
+              service.addCharacteristic(that.Characteristic.Sensitivity);
+              
+            service.getCharacteristic(that.Characteristic.Sensitivity)
+              .on('get', callback => callback(null, 0))
+              .on('set', (value, callback) => callback())
+              .updateValue(0);
+              
+            if(!service.testCharacteristic(that.Characteristic.Duration))
+              service.addCharacteristic(that.Characteristic.Duration);
+              
+            service.getCharacteristic(that.Characteristic.Duration)
+              .on('get', callback => callback(null, 5))
+              .on('set', (value, callback) => callback())
+              .updateValue(5);
+            
+           if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
+
+            this.historyService = new this.FakeGatoHistoryService('motion', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              this.historyService.log = this.log;
+            }
+            
             var value = that.getMotionDetectedCharacteristicValue(jsonObj, null);
             if(null != value) {
                 motionDetectedCharacteristic.updateValue(value);
+                
+                if(value && !accessory.context.cacheValue){
+                
+                  accessory.context.cacheValue = true;
+                
+                  let lastActivation = moment().unix() - this.historyService.getInitialTime();
+                  service.getCharacteristic(that.Characteristic.LastActivation)
+                  .updateValue(lastActivation);
+                
+                }
+                
+                if(!value)
+                  accessory.context.cacheValue = false;
+                
+                this.historyService.addEntry({time: moment().unix(), status:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/MotionSensorParser.js
+++ b/parser/MotionSensorParser.js
@@ -50,11 +50,6 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
         
         var service = new that.Service.MotionSensor(accessoryName);
         service.getCharacteristic(that.Characteristic.MotionDetected);
-        
-        service.addCharacteristic(that.Characteristic.LastActivation);
-        service.addCharacteristic(that.Characteristic.Sensitivity);
-        service.addCharacteristic(that.Characteristic.Duration);
-        
         result.push(service);
         
         var batteryService  = new that.Service.BatteryService(accessoryName);
@@ -73,6 +68,7 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
         var accessory = that.platform.AccessoryUtil.getByUUID(uuid);
         if(accessory) {
             var service = accessory.getService(that.Service.MotionSensor);
+            
             var motionDetectedCharacteristic = service.getCharacteristic(that.Characteristic.MotionDetected);              
             var sensitivityCharacteristic = service.getCharacteristic(that.Characteristic.Sensitivity);              
             var durationCharacteristic = service.getCharacteristic(that.Characteristic.Duration);

--- a/parser/MotionSensorParser.js
+++ b/parser/MotionSensorParser.js
@@ -109,6 +109,8 @@ class MotionSensorMotionSensorParser extends AccessoryParser {
                 
                 if(!value)
                   accessory.context.cacheValue = false;
+                  
+                value = value ? 1 : 0;
                 
                 this.historyService.addEntry({time: moment().unix(), status:value});
             }

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -2,6 +2,8 @@ const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
 
+const history = [];
+
 class TemperatureAndHumiditySensor2Parser extends DeviceParser {
     constructor(platform) {
         super(platform);
@@ -69,16 +71,18 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
                 minValue: -40
             });
             
-           if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
-
-            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              this.historyService.log = this.log;
+           if(!history[accessory.displayName]){
+            
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              
+              history[accessory.displayName].log = this.log;
+          
             }
             
             var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentTemperatureCharacteristic.updateValue(value);
-                this.historyService.addEntry({time: moment().unix(), temp:value, pressure:0, humidity:0});
+                history[accessory.displayName].addEntry({time: moment().unix(), temp:value, pressure:0, humidity:0});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {
@@ -157,16 +161,18 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             var service = accessory.getService(that.Service.HumiditySensor);
             var currentRelativeHumidityCharacteristic = service.getCharacteristic(that.Characteristic.CurrentRelativeHumidity);
             
-           if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
-
-            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              this.historyService.log = this.log;
-            }
+           if(!history[accessory.displayName]){
+            
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              
+              history[accessory.displayName].log = this.log;
+          
+            } 
             
             var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentRelativeHumidityCharacteristic.updateValue(value);
-                this.historyService.addEntry({time: moment().unix(), temp:0, pressure:0, humidity:value});
+                history[accessory.displayName].addEntry({time: moment().unix(), temp:0, pressure:0, humidity:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/TemperatureAndHumiditySensor2Parser.js
+++ b/parser/TemperatureAndHumiditySensor2Parser.js
@@ -73,8 +73,7 @@ class TemperatureAndHumiditySensor2TemperatureSensorParser extends AccessoryPars
             
            if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             }
@@ -163,8 +162,7 @@ class TemperatureAndHumiditySensor2HumiditySensorParser extends AccessoryParser 
             
            if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});             
               history[accessory.displayName].log = this.log;
           
             } 

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -1,5 +1,6 @@
 const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
+const moment = require('moment');
 
 class TemperatureAndHumiditySensorParser extends DeviceParser {
     constructor(platform) {
@@ -19,6 +20,11 @@ module.exports = TemperatureAndHumiditySensorParser;
 class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParser {
     constructor(platform, accessoryType) {
         super(platform, accessoryType)
+        
+        this.FakeGatoHistoryService = require('fakegato-history')(platform.api);        
+        this.HBpath = platform.api.user.storagePath()+'/accessories';
+        this.log = platform.log.log
+        
     }
     
     getAccessoryCategory(deviceSid) {
@@ -62,9 +68,17 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
                 maxValue: 80,
                 minValue: -40
             });
+            
+            if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
+
+            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              this.historyService.log = this.log;
+            }
+            
             var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentTemperatureCharacteristic.updateValue(value);
+                this.historyService.addEntry({time: moment().unix(), temp:value, pressure:0, humidity:0});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {
@@ -99,6 +113,11 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
 class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
     constructor(platform, accessoryType) {
         super(platform, accessoryType)
+        
+        this.FakeGatoHistoryService = require('fakegato-history')(platform.api);        
+        this.HBpath = platform.api.user.storagePath()+'/accessories';
+        this.log = platform.log.log
+        
     }
     
     getAccessoryCategory(deviceSid) {
@@ -138,9 +157,17 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
         if(accessory) {
             var service = accessory.getService(that.Service.HumiditySensor);
             var currentRelativeHumidityCharacteristic = service.getCharacteristic(that.Characteristic.CurrentRelativeHumidity);
+            
+           if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
+
+            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              this.historyService.log = this.log;
+            }
+            
             var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentRelativeHumidityCharacteristic.updateValue(value);
+                this.historyService.addEntry({time: moment().unix(), temp:0, pressure:0, humidity:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -2,6 +2,8 @@ const DeviceParser = require('./DeviceParser');
 const AccessoryParser = require('./AccessoryParser');
 const moment = require('moment');
 
+const history = [];
+
 class TemperatureAndHumiditySensorParser extends DeviceParser {
     constructor(platform) {
         super(platform);
@@ -69,16 +71,18 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
                 minValue: -40
             });
             
-            if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
-
-            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              this.historyService.log = this.log;
-            }
+            if(!history[accessory.displayName]){
+            
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              
+              history[accessory.displayName].log = this.log;
+          
+            } 
             
             var value = that.getCurrentTemperatureCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentTemperatureCharacteristic.updateValue(value);
-                this.historyService.addEntry({time: moment().unix(), temp:value, pressure:0, humidity:0});
+                history[accessory.displayName].addEntry({time: moment().unix(), temp:value, pressure:0, humidity:0});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {
@@ -158,16 +162,19 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
             var service = accessory.getService(that.Service.HumiditySensor);
             var currentRelativeHumidityCharacteristic = service.getCharacteristic(that.Characteristic.CurrentRelativeHumidity);
             
-           if(!this.historyService || (this.historyService && this.historyService.displayName.split(' History')[0] !== accessory.displayName)){
-
-            this.historyService = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              this.historyService.log = this.log;
-            }
+           if(!history[accessory.displayName]){
+            
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
+              
+              history[accessory.displayName].log = this.log;
+          
+            } 
             
             var value = that.getCurrentRelativeHumidityCharacteristicValue(jsonObj, null);
             if(null != value) {
                 currentRelativeHumidityCharacteristic.updateValue(value);
-                this.historyService.addEntry({time: moment().unix(), temp:0, pressure:0, humidity:value});
+
+                history[accessory.displayName].addEntry({time: moment().unix(), temp:0, pressure:0, humidity:value});
             }
             
             if(that.platform.ConfigUtil.getAccessorySyncValue(deviceSid, that.accessoryType)) {

--- a/parser/TemperatureAndHumiditySensorParser.js
+++ b/parser/TemperatureAndHumiditySensorParser.js
@@ -73,8 +73,7 @@ class TemperatureAndHumiditySensorTemperatureSensorParser extends AccessoryParse
             
             if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             } 
@@ -164,8 +163,7 @@ class TemperatureAndHumiditySensorHumiditySensorParser extends AccessoryParser {
             
            if(!history[accessory.displayName]){
             
-              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});
-              
+              history[accessory.displayName] = new this.FakeGatoHistoryService('weather', accessory, {storage:'fs',path:this.HBpath, disableTimer: false, disableRepeatLastData:false});              
               history[accessory.displayName].log = this.log;
           
             } 


### PR DESCRIPTION
Fakegato is a module to emulate Elgato Eve history service in Homebridge accessories, so that it will show in Eve.app

Fakegato: https://github.com/simont77/fakegato-history/blob/master/README.md

This will add Fakegato to Temperature/Humidity Sensors (v1/v2), Motion Sensors (v1/v2) and Contact Sensors(v1/v2)

If you do not want to wait for this pull request, you can already install the version with 'Fakegato' as follows

sudo npm i -g homebridge-mi-aqara-fakegato@latest